### PR TITLE
Too many |s make table values disappear

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -29,7 +29,7 @@
 
 |   Description  |     Value    |
 | -------------- | ------------ |
-| DNS server in use:| (e.g. Default, 176.103.130.130)|
-| How did you setup DNS configuration:| (System/DNSCrypt app/Router)|
-| Device model:| (e.g. Google Pixel)|
-| Operating system and version:| (e.g. Android 7.1.2)|
+| DNS server in use:| (e.g. Default, 176.103.130.130)
+| How did you setup DNS configuration:| (System/DNSCrypt app/Router)
+| Device model:| (e.g. Google Pixel)
+| Operating system and version:| (e.g. Android 7.1.2)


### PR DESCRIPTION
Leaving off the final |s makes it more likely y'all'll _see_ the data we input.